### PR TITLE
Update typescript.vim

### DIFF
--- a/autoload/neomake/makers/ft/typescript.vim
+++ b/autoload/neomake/makers/ft/typescript.vim
@@ -20,7 +20,7 @@ endfunction
 function! neomake#makers#ft#typescript#tslint()
     return {
         \ 'args': [
-            \ '-f', '%:p', '--format verbose'
+            \ '%:p', '--format verbose'
         \ ],
         \ 'errorformat': '%f[%l\, %c]: %m'
         \ }


### PR DESCRIPTION
As described in issue 185 the tslint version 2.5.0 does not support the -f argument. After deleting it the tslint maker works as expected
